### PR TITLE
Fix missing ifdef braces

### DIFF
--- a/Logic_AND_Gate/Logic_AND_Gate.X/mcc_generated_files/include/protected_io.h
+++ b/Logic_AND_Gate/Logic_AND_Gate.X/mcc_generated_files/include/protected_io.h
@@ -91,5 +91,7 @@ extern "C" {
 extern void protected_write_io(void *addr, uint8_t magic, uint8_t value);
 
 /** @} */
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* PROTECTED_IO_H */

--- a/SR_Latch/SR_Latch.X/mcc_generated_files/include/protected_io.h
+++ b/SR_Latch/SR_Latch.X/mcc_generated_files/include/protected_io.h
@@ -91,5 +91,7 @@ extern "C" {
 extern void protected_write_io(void *addr, uint8_t magic, uint8_t value);
 
 /** @} */
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* PROTECTED_IO_H */

--- a/State_Decoder/State_Decoder.X/mcc_generated_files/include/protected_io.h
+++ b/State_Decoder/State_Decoder.X/mcc_generated_files/include/protected_io.h
@@ -91,5 +91,7 @@ extern "C" {
 extern void protected_write_io(void *addr, uint8_t magic, uint8_t value);
 
 /** @} */
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* PROTECTED_IO_H */


### PR DESCRIPTION
The auto-generated version of `protected_io.h` failed to produce the ifdef with the closing brace for when the user is compiling in a C++ environment.

I should note this library was the first one where I noticed this issue, but this issue appears to be prevalent in other AVR Dx libraries, for example [this one](https://github.com/microchip-pic-avr-examples/avr128da48-cnano-rnbd-rn487x-gettingstarted-mplab-mcc/blob/master/avr128da48_rnbd451_transparent_uart_example.X/mcc_generated_files/system/protected_io.h).